### PR TITLE
[MiningAssistants] Added instantiation-[target|exclusion]-relations option

### DIFF
--- a/mining/src/main/java/amie/mining/assistant/DefaultMiningAssistant.java
+++ b/mining/src/main/java/amie/mining/assistant/DefaultMiningAssistant.java
@@ -420,6 +420,17 @@ public class DefaultMiningAssistant extends MiningAssistant{
 	protected void getInstantiatedAtoms(Rule query, Rule parentQuery, 
 			int bindingTriplePos, int danglingPosition, double minSupportThreshold, Collection<Rule> output) {
 		int[] danglingEdge = query.getTriples().get(bindingTriplePos);
+
+		if (this.instantiationExcludedRelations != null
+				&& this.instantiationExcludedRelations.contains(danglingEdge[1])) {
+			return;
+		}
+
+		if (this.instantiationTargetRelations != null
+				&& !this.instantiationTargetRelations.contains(danglingEdge[1])) {
+			return;
+		}
+
 		Rule rewrittenQuery = null;
 		if (!query.isEmpty() && this.enableQueryRewriting) {
 			rewrittenQuery = rewriteProjectionQuery(query, bindingTriplePos, danglingPosition == 0 ? 2 : 0);

--- a/mining/src/main/java/amie/mining/assistant/MiningAssistant.java
+++ b/mining/src/main/java/amie/mining/assistant/MiningAssistant.java
@@ -125,11 +125,21 @@ public class MiningAssistant {
 	 * List of excluded relations for the head of rules;
 	 */
 	protected IntCollection headExcludedRelations;
+
+	/**
+	 * List of excluded relations for the instantiation mining operator;
+	 */
+	protected IntCollection instantiationExcludedRelations;
 	
 	/**
 	 * List of target relations for the body of rules;
 	 */
 	protected IntCollection bodyTargetRelations;
+
+	/**
+	 * List of target relations for the instantiation mining operator;
+	 */
+	protected IntCollection instantiationTargetRelations;
 
 	/**
 	 * Count directly on subject or use functional information
@@ -1211,6 +1221,17 @@ public class MiningAssistant {
 	protected void getInstantiatedAtoms(Rule queryWithDanglingEdge, Rule parentQuery, 
 			int danglingAtomPosition, int danglingPositionInEdge, double minSupportThreshold, Collection<Rule> output) {
 		int[] danglingEdge = queryWithDanglingEdge.getTriples().get(danglingAtomPosition);
+
+		if (this.instantiationExcludedRelations != null
+				&& this.instantiationExcludedRelations.contains(danglingEdge[1])) {
+			return;
+		}
+
+		if (this.instantiationTargetRelations != null
+				&& !this.instantiationTargetRelations.contains(danglingEdge[1])) {
+			return;
+		}
+
 		Int2IntMap constants = kb.frequentBindingsOf(danglingEdge[danglingPositionInEdge], 
 				queryWithDanglingEdge.getFunctionalVariable(), queryWithDanglingEdge.getTriples());
 		for (int constant: constants.keySet()){
@@ -1425,6 +1446,24 @@ public class MiningAssistant {
 	public void setHeadExcludedRelations(
 			IntCollection headExcludedRelations) {
 		this.headExcludedRelations = headExcludedRelations;
+	}
+
+	public IntCollection getInstantiationExcludedRelations() {
+		return instantiationExcludedRelations;
+	}
+
+	public void setInstantiationExcludedRelations(
+			IntCollection instantiationExcludedRelations) {
+		this.instantiationExcludedRelations = instantiationExcludedRelations;
+	}
+
+	public IntCollection getInstantiationTargetRelations() {
+		return instantiationTargetRelations;
+	}
+
+	public void setInstantiationTargetRelations(
+			IntCollection instantiationTargetRelations) {
+		this.instantiationTargetRelations = instantiationTargetRelations;
 	}
 
 	public IntCollection getBodyTargetRelations() {


### PR DESCRIPTION
_I'm not sure if this feature is relevant to AMIE, so feel free to close this PR without merge._

---------

This PR adds the AMIE arguments `-itr` (instantiation-target-relations) and `-iexr` (instantiation-excluded-relations), and are used by `MiningAssistant` and `DefaultMiningAssistant`.

These arguments behave similar to `-htr/hexr` and `-btr/bexr`, but they specify which relations may (or must not) be instantiated when `-const` or `-fconst` is specified.

## Use case

This feature emerged from my own project's requirements, where I'm specially interested in mining rules with contants. Nonetheless, I noticed that in my ontology, some relations are just hops between entities, while some other relations indeed can be considered to represent facts about a given entity.

Therefore, I described which relations must not be instantiated, and then `-iexr` followed. Complementary, I've added `-itr`, although I'm not really using it.

## Implementation

The implementation is based on `-htr/hexr` and `-btr/bexr`, and have been applied to `MiningAssistant` and `DefaultMiningAssistant`, i.e., the other mining assistants are not aware of `-itr/iexr`.