### PR TITLE
Add calls to KB.unmap when printing to console (#11)

### DIFF
--- a/kb/src/main/java/amie/data/KB.java
+++ b/kb/src/main/java/amie/data/KB.java
@@ -943,7 +943,7 @@ public class KB {
 				return ((double) relation2subject2object.get(relation).size() / relationSize
 					.get(relation));
 			} else {
-				throw new IllegalArgumentException("The relation " + relation + " was not found in the KB");
+				throw new IllegalArgumentException("The relation " + KB.unmap(relation) + " was not found in the KB");
 			}
 		}
 	}
@@ -968,7 +968,7 @@ public class KB {
 				return ((double) relation2object2subject.get(relation).size() / relationSize
 						.get(relation));
 			} else {
-				throw new IllegalArgumentException("The relation " + relation + " was not found in the KB");
+				throw new IllegalArgumentException("The relation " + KB.unmap(relation) + " was not found in the KB");
 			}
 		}
 	}
@@ -4579,7 +4579,7 @@ public class KB {
 		Int2ObjectMap<IntSet> imap2 = index.get(s1);
 		IntSet imap3 = imap2.get(s2);
 		if (imap3 == null) {
-			System.out.println("Problem for prediction " + s1 + " " + s2 + " " + s3);
+			System.out.println("Problem for prediction " + KB.unmap(s1) + " " + KB.unmap(s2) + " " + KB.unmap(s3));
 		}
 		imap3.remove(s3);
 		if (imap3.isEmpty()) {
@@ -4605,7 +4605,7 @@ public class KB {
 					+ "\tInverse functionality\tVariance\tInverse Variance"
 					+ "\tNumber of subjects\tNumber of objects");
 			for(int relation: relationSize.keySet()){
-				System.out.println(relation + "\t" + relationSize.get(relation) + 
+				System.out.println(KB.unmap(relation) + "\t" + relationSize.get(relation) +
 						"\t" + functionality(relation) + 
 						"\t" + inverseFunctionality(relation) + 
 						"\t" + variance(relation) +
@@ -4642,7 +4642,7 @@ public class KB {
 			if (ommittedRelations.contains(relation))
 				continue;
 			
-			System.out.println(relation);
+			System.out.println(KB.unmap(relation));
 			IntHashMap<Integer> distribution = new IntHashMap<>();
 			Int2ObjectMap<IntSet> theMap = null;
 			boolean isFunctional = isFunctional(relation);
@@ -4669,9 +4669,9 @@ public class KB {
 						distribution.increase(0);
 						if (Math.random() >= 0.9) {
 							if (isFunctional)
-								writer.write(instance + "\t" + relation + "\t" + "NULL\n");
+								writer.write(KB.unmap(instance) + "\t" + KB.unmap(relation) + "\t" + "NULL\n");
 							else
-								writer.write("NULL" + "\t" + relation + "\t" + instance + "\n");
+								writer.write("NULL" + "\t" + KB.unmap(relation) + "\t" + KB.unmap(instance) + "\n");
 						}
 					}
 				}				
@@ -4723,7 +4723,7 @@ public class KB {
 			Int2ObjectMap<IntSet> map = 
 					relation2object2subject.get(Schema.typeRelationBS);
 			for (int type : map.keySet()) {
-				System.out.println(type + "\t" + map.get(type).size());
+				System.out.println(KB.unmap(type) + "\t" + map.get(type).size());
 			}
 		}
 	}

--- a/kb/src/main/java/amie/data/utils/KBsSummarizer.java
+++ b/kb/src/main/java/amie/data/utils/KBsSummarizer.java
@@ -2,6 +2,7 @@ package amie.data.utils;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.stream.Collectors;
 
 
 import amie.data.KB;
@@ -67,7 +68,7 @@ public class KBsSummarizer {
 			} else {
 				db2.summarize(true);	
 			}
-			System.out.println(relationsInCommon);
+			System.out.println(relationsInCommon.stream().map(KB::unmap).collect(Collectors.toList()));
 		}
 	}
 }

--- a/mining/src/main/java/amie/mining/AMIE.java
+++ b/mining/src/main/java/amie/mining/AMIE.java
@@ -1341,7 +1341,7 @@ public class AMIE {
      */
     public static void main(String[] args) throws Exception {
         Schema.loadSchemaConf();
-        System.out.println("Assuming " + Schema.typeRelationBS + " as type relation");
+        System.out.println("Assuming " + KB.unmap(Schema.typeRelationBS) + " as type relation");
         long loadingStartTime = System.currentTimeMillis();
         AMIE miner = AMIE.getInstance(args);
         long loadingTime = System.currentTimeMillis() - loadingStartTime;

--- a/mining/src/main/java/amie/mining/assistant/DefaultMiningAssistant.java
+++ b/mining/src/main/java/amie/mining/assistant/DefaultMiningAssistant.java
@@ -173,14 +173,14 @@ public class DefaultMiningAssistant extends MiningAssistant{
 								promisingRelations = kb.countProjectionBindings(rule.getHead(), rule.getAntecedent(), newEdge[1]);
 								long t2 = System.currentTimeMillis();
 								if((t2 - t1) > 20000 && this.verbose)
-									System.err.println("countProjectionBindings var=" + newEdge[1] + " "  + rule + " has taken " + (t2 - t1) + " ms");
+									System.err.println("countProjectionBindings var=" + KB.unmap(newEdge[1]) + " "  + rule + " has taken " + (t2 - t1) + " ms");
 							}else{
 								System.out.println(rewrittenQuery + " is a rewrite of " + rule);
 								long t1 = System.currentTimeMillis();
 								promisingRelations = kb.countProjectionBindings(rewrittenQuery.getHead(), rewrittenQuery.getAntecedent(), newEdge[1]);
 								long t2 = System.currentTimeMillis();
 								if((t2 - t1) > 20000 && this.verbose)
-									System.err.println("countProjectionBindings on rewritten query var=" + newEdge[1] + " "  + rewrittenQuery + " has taken " + (t2 - t1) + " ms");						
+									System.err.println("countProjectionBindings on rewritten query var=" + KB.unmap(newEdge[1]) + " "  + rewrittenQuery + " has taken " + (t2 - t1) + " ms");
 							}
 						} else {
 							promisingRelations = this.kb.countProjectionBindings(rule.getHead(), rule.getAntecedent(), newEdge[1]);
@@ -297,14 +297,14 @@ public class DefaultMiningAssistant extends MiningAssistant{
 					promisingRelations = this.kb.countProjectionBindings(query.getHead(), query.getAntecedent(), newEdge[1]);
 					long t2 = System.currentTimeMillis();
 					if((t2 - t1) > 20000 && this.verbose) {
-						System.err.println("countProjectionBindings var=" + newEdge[1] + " "  + query + " has taken " + (t2 - t1) + " ms");
+						System.err.println("countProjectionBindings var=" + KB.unmap(newEdge[1]) + " "  + query + " has taken " + (t2 - t1) + " ms");
 					}
 				}else{
 					long t1 = System.currentTimeMillis();
 					promisingRelations = this.kb.countProjectionBindings(rewrittenQuery.getHead(), rewrittenQuery.getAntecedent(), newEdge[1]);
 					long t2 = System.currentTimeMillis();
 					if((t2 - t1) > 20000 && this.verbose)
-					System.err.println("countProjectionBindings on rewritten query var=" + newEdge[1] + " "  + rewrittenQuery + " has taken " + (t2 - t1) + " ms");						
+					System.err.println("countProjectionBindings on rewritten query var=" + KB.unmap(newEdge[1]) + " "  + rewrittenQuery + " has taken " + (t2 - t1) + " ms");
 				}
 				
 				query.getTriples().remove(nPatterns);					
@@ -431,13 +431,13 @@ public class DefaultMiningAssistant extends MiningAssistant{
 			constants = this.kb.countProjectionBindings(rewrittenQuery.getHead(), rewrittenQuery.getAntecedent(), danglingEdge[danglingPosition]);
 			long t2 = System.currentTimeMillis();
 			if((t2 - t1) > 20000 && this.verbose)
-				System.err.println("countProjectionBindings var=" + danglingEdge[danglingPosition] + " in " + query + " (rewritten to " + rewrittenQuery + ") has taken " + (t2 - t1) + " ms");						
+				System.err.println("countProjectionBindings var=" + KB.unmap(danglingEdge[danglingPosition]) + " in " + query + " (rewritten to " + rewrittenQuery + ") has taken " + (t2 - t1) + " ms");
 		}else{
 			long t1 = System.currentTimeMillis();		
 			constants = this.kb.countProjectionBindings(query.getHead(), query.getAntecedent(), danglingEdge[danglingPosition]);
 			long t2 = System.currentTimeMillis();
 			if((t2 - t1) > 20000 && this.verbose)
-				System.err.println("countProjectionBindings var=" + danglingEdge[danglingPosition] + " in " + query + " has taken " + (t2 - t1) + " ms");			
+				System.err.println("countProjectionBindings var=" + KB.unmap(danglingEdge[danglingPosition]) + " in " + query + " has taken " + (t2 - t1) + " ms");
 		}
 		
 		int joinPosition = (danglingPosition == 0 ? 2 : 0);
@@ -541,7 +541,7 @@ public class DefaultMiningAssistant extends MiningAssistant{
 		long t2 = System.currentTimeMillis();	
 		query.setConfidenceRunningTime(t2 - t1);
 		if((t2 - t1) > 20000 && this.verbose) {
-			System.err.println("countPairs vars " + var1 + ", " + var2 + " in " + KB.toString(query.getAntecedent()) + " has taken " + (t2 - t1) + " ms");
+			System.err.println("countPairs vars " + KB.unmap(var1) + ", " + KB.unmap(var2) + " in " + KB.toString(query.getAntecedent()) + " has taken " + (t2 - t1) + " ms");
 		}
 		return result;
 	}
@@ -563,7 +563,7 @@ public class DefaultMiningAssistant extends MiningAssistant{
 		long t2 = System.currentTimeMillis();
 		query.setPcaConfidenceRunningTime(t2 - t1);
 		if((t2 - t1) > 20000 && this.verbose) {
-			System.err.println("countPairs vars " + var1 + ", " + var2 + " in " + KB.toString(antecedent) + " has taken " + (t2 - t1) + " ms");
+			System.err.println("countPairs vars " + KB.unmap(var1) + ", " + KB.unmap(var2) + " in " + KB.toString(antecedent) + " has taken " + (t2 - t1) + " ms");
 		}
 		return result;
 	}

--- a/mining/src/main/java/amie/mining/assistant/experimental/LazyIteratorMiningAssistant.java
+++ b/mining/src/main/java/amie/mining/assistant/experimental/LazyIteratorMiningAssistant.java
@@ -78,7 +78,7 @@ public class LazyIteratorMiningAssistant extends LazyMiningAssistant {
         long t2 = System.currentTimeMillis();
         query.setPcaConfidenceRunningTime(t2 - t1);
         if ((t2 - t1) > 20000 && this.verbose) {
-            System.err.println("countPairs vars " + var1 + ", " + var2 + " in " + KB.toString(antecedent) + " has taken " + (t2 - t1) + " ms");
+            System.err.println("countPairs vars " + KB.unmap(var1) + ", " + KB.unmap(var2) + " in " + KB.toString(antecedent) + " has taken " + (t2 - t1) + " ms");
         }
         return result;
     }
@@ -104,7 +104,7 @@ public class LazyIteratorMiningAssistant extends LazyMiningAssistant {
         long t2 = System.currentTimeMillis();
         query.setConfidenceRunningTime(t2 - t1);
         if ((t2 - t1) > 20000 && this.verbose) {
-            System.err.println("countPairs vars " + var1 + ", " + var2 + " in " + KB.toString(query.getAntecedent()) + " has taken " + (t2 - t1) + " ms");
+            System.err.println("countPairs vars " + KB.unmap(var1) + ", " + KB.unmap(var2) + " in " + KB.toString(query.getAntecedent()) + " has taken " + (t2 - t1) + " ms");
         }
         return result;
     }

--- a/mining/src/main/java/amie/mining/assistant/experimental/LazyMiningAssistant.java
+++ b/mining/src/main/java/amie/mining/assistant/experimental/LazyMiningAssistant.java
@@ -79,7 +79,7 @@ public class LazyMiningAssistant extends DefaultMiningAssistantWithOrder {
         long t2 = System.currentTimeMillis();
         query.setPcaConfidenceRunningTime(t2 - t1);
         if ((t2 - t1) > 20000 && this.verbose) {
-            System.err.println("countPairs vars " + var1 + ", " + var2 + " in " + KB.toString(antecedent) + " has taken " + (t2 - t1) + " ms");
+            System.err.println("countPairs vars " + KB.unmap(var1) + ", " + KB.unmap(var2) + " in " + KB.toString(antecedent) + " has taken " + (t2 - t1) + " ms");
         }
         return result;
     }
@@ -105,7 +105,7 @@ public class LazyMiningAssistant extends DefaultMiningAssistantWithOrder {
         long t2 = System.currentTimeMillis();
         query.setConfidenceRunningTime(t2 - t1);
         if ((t2 - t1) > 20000 && this.verbose) {
-            System.err.println("countPairs vars " + var1 + ", " + var2 + " in " + KB.toString(query.getAntecedent()) + " has taken " + (t2 - t1) + " ms");
+            System.err.println("countPairs vars " + KB.unmap(var1) + ", " + KB.unmap(var2) + " in " + KB.toString(query.getAntecedent()) + " has taken " + (t2 - t1) + " ms");
         }
         return result;
     }

--- a/mining/src/main/java/amie/mining/assistant/experimental/TypingMiningAssistant.java
+++ b/mining/src/main/java/amie/mining/assistant/experimental/TypingMiningAssistant.java
@@ -132,14 +132,14 @@ public class TypingMiningAssistant extends DefaultMiningAssistant {
 					promisingRelations = this.kb.countProjectionBindings(query.getHead(), query.getAntecedent(), newEdge[1]);
 					long t2 = System.currentTimeMillis();
 					if((t2 - t1) > 20000 && this.verbose) {
-						System.err.println("countProjectionBindings var=" + newEdge[1] + " "  + query + " has taken " + (t2 - t1) + " ms");
+						System.err.println("countProjectionBindings var=" + KB.unmap(newEdge[1]) + " "  + query + " has taken " + (t2 - t1) + " ms");
 					}
 				}else{
 					long t1 = System.currentTimeMillis();
 					promisingRelations = this.kb.countProjectionBindings(rewrittenQuery.getHead(), rewrittenQuery.getAntecedent(), newEdge[1]);
 					long t2 = System.currentTimeMillis();
 					if((t2 - t1) > 20000 && this.verbose)
-					System.err.println("countProjectionBindings on rewritten query var=" + newEdge[1] + " "  + rewrittenQuery + " has taken " + (t2 - t1) + " ms");						
+					System.err.println("countProjectionBindings on rewritten query var=" + KB.unmap(newEdge[1]) + " "  + rewrittenQuery + " has taken " + (t2 - t1) + " ms");
 				}
 				
 				query.getTriples().remove(nPatterns);								

--- a/rules/src/main/java/amie/rules/Rule.java
+++ b/rules/src/main/java/amie/rules/Rule.java
@@ -1510,7 +1510,7 @@ public class Rule {
 	        strBuilder.append("\t" + df1.format(getSupport()));
 	        strBuilder.append("\t" + df1.format(getBodySize()));
 	        strBuilder.append("\t" + df1.format(getPcaBodySize()));
-	        strBuilder.append("\t" + getFunctionalVariable());
+	        strBuilder.append("\t" + KB.unmap(getFunctionalVariable()));
 	        strBuilder.append("\t" + stdConfidenceUpperBound);
 	        strBuilder.append("\t" + pcaConfidenceUpperBound);
 	        strBuilder.append("\t" + pcaConfidenceEstimation);
@@ -1528,7 +1528,7 @@ public class Rule {
 	        	strBuilder.append("\t" + df1.format(getBodySize()));
 	        if (!metricsList.contains(Metric.PCABodySize))
 	        	strBuilder.append("\t" + df1.format(getPcaBodySize()));
-	        strBuilder.append("\t" + getFunctionalVariable());
+	        strBuilder.append("\t" + KB.unmap(getFunctionalVariable()));
 	        strBuilder.append("\t" + stdConfidenceUpperBound);
 	        strBuilder.append("\t" + pcaConfidenceUpperBound);
 	        strBuilder.append("\t" + pcaConfidenceEstimation);
@@ -1544,7 +1544,7 @@ public class Rule {
 	        strBuilder.append("\t" + df.format(getSupport()));
 	        strBuilder.append("\t" + getBodySize());
 	        strBuilder.append("\t" + df.format(getPcaBodySize()));
-	        strBuilder.append("\t" + getFunctionalVariable());
+	        strBuilder.append("\t" + KB.unmap(getFunctionalVariable()));
     	} else {
         	List<Metric> metricsList = Arrays.asList(metrics2Ommit);
         	if (!metricsList.contains(Metric.HeadCoverage))
@@ -1559,7 +1559,7 @@ public class Rule {
 	        	strBuilder.append("\t" + getBodySize());
 	        if (!metricsList.contains(Metric.PCABodySize))
 	        	strBuilder.append("\t" + df.format(getPcaBodySize()));
-	        strBuilder.append("\t" + getFunctionalVariable());
+	        strBuilder.append("\t" + KB.unmap(getFunctionalVariable()));
     	}
     }
 
@@ -1586,7 +1586,7 @@ public class Rule {
 
     public static String toDatalog(int[] atom) {
         return KB.unmap(atom[1]).replace("<", "").replace(">", "")
-        		+ "(" + atom[0] + ", " + atom[2] + ")";
+                + "(" + KB.unmap(atom[0]) + ", " + KB.unmap(atom[2]) + ")";
     }
 
     public String getDatalogString() {

--- a/rules/src/main/java/amie/rules/eval/EntitiesRelationSampler.java
+++ b/rules/src/main/java/amie/rules/eval/EntitiesRelationSampler.java
@@ -75,7 +75,7 @@ public class EntitiesRelationSampler {
 		
 		for(int relation: relationsMap.keySet()){
 			for(IntPair entityObject: relationsMap.get(relation))
-				System.out.println(entityObject.first + "\t" + relation + "\t" + entityObject.second);
+				System.out.println(KB.unmap(entityObject.first) + "\t" + KB.unmap(relation) + "\t" + KB.unmap(entityObject.second));
 		}
 		
 	}


### PR DESCRIPTION
This PR adds calls to `KB.unmap` where it looked right to do so, i.e., when printing to console. I've manually checked calls to `System.err.`, `System.out.`, and `writer.write`.

This *might* break things if such things depend, e.g., on the current/wrong output:

|Rule|Head Coverage|Std Confidence|PCA Confidence|Positive Examples|Body size|PCA Body size|Functional variable|Std. Lower Bound|PCA Lower Bound|PCA Conf estimation|
|----|----|----|----|----|----|----|----|----|----|----|
|?b  &lt;relation&gt;  ?a   => ?a  &lt;relation&gt;  ?b|1| 1| 1| 2| 2| 2| **-1**|0.0|0.0|0.0|

instead of the new/correct output:
|Rule|Head Coverage|Std Confidence|PCA Confidence|Positive Examples|Body size|PCA Body size|Functional variable|Std. Lower Bound|PCA Lower Bound|PCA Conf estimation|
|----|----|----|----|----|----|----|----|----|----|----|
|?b  &lt;relation&gt;  ?a   => ?a  &lt;relation&gt;  ?b|1| 1| 1| 2| 2| 2| **?a**|0.0|0.0|0.0|
