### PR TITLE
Tests for rule parsing + small bug fix - #21

### DIFF
--- a/kb/src/main/java/amie/data/KB.java
+++ b/kb/src/main/java/amie/data/KB.java
@@ -3761,7 +3761,7 @@ public class KB {
 		if (m.find())
 			return (triple(m.group(2).trim(), m.group(1).trim(), m.group(3).trim()));
 		m = amieTriplePattern.matcher(s);
-		if (!m.find())
+		if (m.find())
 			return (triple(m.group(1).trim(), m.group(2).trim(), m.group(3).trim()));
 		return (null);
 	}

--- a/kb/src/test/java/amie/data/TestKBRuleParsing.java
+++ b/kb/src/test/java/amie/data/TestKBRuleParsing.java
@@ -1,0 +1,109 @@
+package amie.data;
+
+import javatools.datatypes.Pair;
+import junit.framework.TestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+// TODO test datalog representation
+public class TestKBRuleParsing extends TestCase {
+
+    List<Pair<List<int[]>, int[]>> cases;
+
+    public void setUp() throws Exception {
+        super.setUp();
+        cases = new ArrayList<>();
+
+        // 2 triples pattern
+        Pair<List<int[]>, int[]> q0 = new Pair<>(
+                KB.triples(KB.triple("bob", "loves", "?x2")),
+                KB.triple("?x2", "livesIn", "?x3")
+        );
+        cases.add(q0);
+
+        // Multiple triples pattern with < >
+        Pair<List<int[]>, int[]> q1 = new Pair<>(
+                KB.triples(
+                        KB.triple("?a", "<hasZ>", "?b"), KB.triple("?g", "<connectsTo>", "?a"),
+                        KB.triple("?n", "<hasZ>", "?b"), KB.triple("?g", "<relatesTo>", "?a")
+                ),
+                KB.triple("?g", "<relatesTo>", "?n")
+        );
+        cases.add(q1);
+
+        // 2-triple pattern with / and number
+        Pair<List<int[]>, int[]> q2 = new Pair<>(
+                KB.triples(KB.triple("?a", "/film/actor/film./film/performance/film", "/m/0340hj")),
+                KB.triple("?a", "neg_/award/award_nominee/award_nominations./award/award_nomination/award", "/m/02x8n1n")
+        );
+        cases.add(q2);
+
+        // 2-triple pattern with _
+        Pair<List<int[]>, int[]> q3 = new Pair<>(
+                KB.triples(KB.triple("bob", "really_loves", "?x2")),
+                KB.triple("?x2", "lives_in", "?x3")
+        );
+        cases.add(q3);
+
+        // 2-triple pattern with multiple _
+        Pair<List<int[]>, int[]> q4 = new Pair<>(
+                KB.triples(KB.triple("bob", "loves_very_much", "?x2")),
+                KB.triple("?x2", "currently_lives_in", "?x3")
+        );
+        cases.add(q4);
+
+        // 2-triple pattern with /
+        Pair<List<int[]>, int[]> q5 = new Pair<>(
+                KB.triples(KB.triple("?a", "/film/actor/film./film/performance/film", "/m/abc")),
+                KB.triple("?a", "neg_/award/award_nominee/award_nominations./award/award_nomination/award", "/m/dfg")
+        );
+        cases.add(q5);
+
+        // 2-triple pattern with number
+        Pair<List<int[]>, int[]> q6 = new Pair<>(
+                KB.triples(KB.triple("bob", "s2", "?x2")),
+                KB.triple("?x2", "lives_in", "?x3")
+        );
+        cases.add(q6);
+    }
+
+    private void runTestCaseId(int case_id) {
+        Pair<List<int[]>, int[]> c = cases.get(case_id);
+        String expected = KB.toString(c.first) + " => " + KB.toString(c.second);
+        Pair<List<int[]>, int[]> result = KB.rule(expected);
+
+        assertNotNull("expected:<" + expected + ">", result);
+        String actual = KB.toString(result.first) + " => " + KB.toString(result.second);
+        System.out.println(expected + "\n" + actual);
+        assertEquals(expected, actual);
+    }
+
+    public void test0() {
+        runTestCaseId(0);
+    }
+
+    public void test1() {
+        runTestCaseId(1);
+    }
+
+    public void test2() {
+        runTestCaseId(2);
+    }
+
+    public void test3() {
+        runTestCaseId(3);
+    }
+
+    public void test4() {
+        runTestCaseId(4);
+    }
+
+    public void test5() {
+        runTestCaseId(5);
+    }
+
+    public void test6() {
+        runTestCaseId(6);
+    }
+}

--- a/kb/src/test/java/amie/data/TestKBTripleParsing.java
+++ b/kb/src/test/java/amie/data/TestKBTripleParsing.java
@@ -1,0 +1,90 @@
+package amie.data;
+
+import javatools.datatypes.Pair;
+import junit.framework.TestCase;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+// TODO test datalog representation
+public class TestKBTripleParsing extends TestCase {
+
+    List<Pair<int[], int[]>> cases;
+
+    public void setUp() throws Exception {
+        super.setUp();
+        cases = new ArrayList<>();
+
+        // 2 triples pattern
+        List<String[]> triples = Arrays.asList(
+                new String[]{"bob", "loves", "?x2"},
+                new String[]{"bob", "loves_very_much", "?x2"},
+                new String[]{"bob", "s2", "?x2"},
+                new String[]{"?x2", "livesIn", "?x3"},
+                new String[]{"?x2", "currently_lives_in", "?x3"},
+                new String[]{"?g", "<connectsTo>", "?a"},
+                new String[]{"?x2", "lives_in", "?x3"},
+                new String[]{"?a", "/film/actor/film./film/performance/film", "/m/0340hj"},
+                new String[]{"?a", "neg_/award/award_nominee/award_nominations./award/award_nomination/award", "/m/02x8n1n"},
+                new String[]{"?a", "/film/actor/film./film/performance/film", "/m/abc"},
+                new String[]{"?a", "neg_/award/award_nominee/award_nominations./award/award_nomination/award", "/m/dfg"}
+        );
+
+        for (String[] triple : triples) {
+            Pair<int[], int[]> p = new Pair<>(KB.triple(triple), KB.triple(String.join(" ", triple)));
+            cases.add(p);
+        }
+    }
+
+    private void runTestCaseId(int case_id) {
+        String q1 = KB.toString(cases.get(case_id).first);
+        int[] q2 = cases.get(case_id).second;
+        assertNotNull("expected:<" + q1 + ">", q2);
+        assertEquals(q1, KB.toString(q2));
+    }
+
+    public void test0() {
+        runTestCaseId(0);
+    }
+
+    public void test1() {
+        runTestCaseId(1);
+    }
+
+    public void test2() {
+        runTestCaseId(2);
+    }
+
+    public void test3() {
+        runTestCaseId(3);
+    }
+
+    public void test4() {
+        runTestCaseId(4);
+    }
+
+    public void test5() {
+        runTestCaseId(5);
+    }
+
+    public void test6() {
+        runTestCaseId(6);
+    }
+
+    public void test7() {
+        runTestCaseId(7);
+    }
+
+    public void test8() {
+        runTestCaseId(8);
+    }
+
+    public void test9() {
+        runTestCaseId(9);
+    }
+
+    public void test10() {
+        runTestCaseId(10);
+    }
+}

--- a/kb/src/test/java/amie/data/TestKBTriplesParsing.java
+++ b/kb/src/test/java/amie/data/TestKBTriplesParsing.java
@@ -1,0 +1,111 @@
+package amie.data;
+
+import javatools.datatypes.Pair;
+import junit.framework.TestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+// TODO test datalog representation
+public class TestKBTriplesParsing extends TestCase {
+
+    List<Pair<List<int[]>, List<int[]>>> cases;
+
+    public void setUp() throws Exception {
+        super.setUp();
+        cases = new ArrayList<>();
+
+        // 2 triples pattern
+        List<int[]> q01 = KB.triples(KB.triple("bob", "loves", "?x2"),
+                KB.triple("?x2", "livesIn", "?x3"));
+        List<int[]> q02 = KB.triples("bob loves ?x2  ?x2 livesIn ?x3");
+        Pair<List<int[]>, List<int[]>> p0 = new Pair<>(q01, q02);
+        cases.add(p0);
+
+        // Multiple triples pattern with < >
+        List<int[]> q11 = KB.triples(
+                KB.triple("?a", "<hasZ>", "?b"),
+                KB.triple("?g", "<connectsTo>", "?a"), KB.triple("?n", "<hasZ>", "?b"),
+                KB.triple("?g", "<relatesTo>", "?a"), KB.triple("?g", "<relatesTo>", "?n")
+        );
+        List<int[]> q12 = KB.triples("?a  <hasZ>  ?b  ?g  <connectsTo>  ?a  ?n  <hasZ>  ?b  ?g  <relatesTo>  ?a  ?g  <relatesTo>  ?n");
+        Pair<List<int[]>, List<int[]>> p1 = new Pair<>(q11, q12);
+        cases.add(p1);
+
+        // 2-triple pattern with / and number
+        List<int[]> q21 = KB.triples(
+                KB.triple("?a", "/film/actor/film./film/performance/film", "/m/0340hj"),
+                KB.triple("?a", "neg_/award/award_nominee/award_nominations./award/award_nomination/award", "/m/02x8n1n")
+        );
+        List<int[]> q22 = KB.triples("?a /film/actor/film./film/performance/film /m/0340hj " +
+                "?a neg_/award/award_nominee/award_nominations./award/award_nomination/award /m/02x8n1n");
+        Pair<List<int[]>, List<int[]>> p2 = new Pair<>(q21, q22);
+        cases.add(p2);
+
+        // 2-triple pattern with _
+        List<int[]> q31 = KB.triples(KB.triple("bob", "really_loves", "?x2"),
+                KB.triple("?x2", "lives_in", "?x3"));
+        List<int[]> q32 = KB.triples("bob really_loves ?x2  ?x2 lives_in ?x3");
+        Pair<List<int[]>, List<int[]>> p3 = new Pair<>(q31, q32);
+        cases.add(p3);
+
+        // 2-triple pattern with multiple _
+        List<int[]> q41 = KB.triples(KB.triple("bob", "loves_very_much", "?x2"),
+                KB.triple("?x2", "currently_lives_in", "?x3"));
+        List<int[]> q42 = KB.triples("bob loves_very_much ?x2  ?x2 currently_lives_in ?x3");
+        Pair<List<int[]>, List<int[]>> p4 = new Pair<>(q41, q42);
+        cases.add(p4);
+
+        // 2-triple pattern with /
+        List<int[]> q51 = KB.triples(
+                KB.triple("?a", "/film/actor/film./film/performance/film", "/m/abc"),
+                KB.triple("?a", "neg_/award/award_nominee/award_nominations./award/award_nomination/award", "/m/dfg")
+        );
+        List<int[]> q52 = KB.triples("?a /film/actor/film./film/performance/film /m/abc " +
+                "?a neg_/award/award_nominee/award_nominations./award/award_nomination/award /m/dfg");
+        Pair<List<int[]>, List<int[]>> p5 = new Pair<>(q51, q52);
+        cases.add(p5);
+
+        // 2-triple pattern with number
+        List<int[]> q61 = KB.triples(KB.triple("bob", "s2", "?x2"),
+                KB.triple("?x2", "lives_in", "?x3"));
+        List<int[]> q62 = KB.triples("bob s2 ?x2  ?x2 lives_in ?x3");
+        Pair<List<int[]>, List<int[]>> p6 = new Pair<>(q61, q62);
+        cases.add(p6);
+    }
+
+    private void runTestCaseId(int case_id) {
+        String q1 = KB.toString(cases.get(case_id).first);
+        List<int[]> q2 = cases.get(case_id).second;
+        assertNotNull("expected:<" + q1 + ">", q2);
+        assertEquals(q1, KB.toString(q2));
+    }
+
+    public void test0() {
+        runTestCaseId(0);
+    }
+
+    public void test1() {
+        runTestCaseId(1);
+    }
+
+    public void test2() {
+        runTestCaseId(2);
+    }
+
+    public void test3() {
+        runTestCaseId(3);
+    }
+
+    public void test4() {
+        runTestCaseId(4);
+    }
+
+    public void test5() {
+        runTestCaseId(5);
+    }
+
+    public void test6() {
+        runTestCaseId(6);
+    }
+}


### PR DESCRIPTION
This PR adds tests for `KB.triple`, `KB.triples`, and `KB.rule`. Their intent is to help spotting problems on the regex patterns used to parse triples/rules.

The tests covers only AMIE triples representation. Datalog triples were not tested.

It also contain a small bug fix to `KB.triple`, although this function seems to never be used.