### PR TITLE
[AMIEParser] Read TSV support + load rule metrics

### DIFF
--- a/mining/src/main/java/amie/mining/utils/TSVRuleIsSkyline.java
+++ b/mining/src/main/java/amie/mining/utils/TSVRuleIsSkyline.java
@@ -49,12 +49,9 @@ public class TSVRuleIsSkyline {
             if (record1.size() < 7) {
                 continue;
             }
-            Rule q = AMIEParser.rule(record1.get(0));
+            Rule q = AMIEParser.rule(record1);
             if (q == null) continue;
-            q.setSupport(Integer.parseInt(record1.get(4)));
-            q.setBodySize(Integer.parseInt(record1.get(5)));
-            q.setPcaBodySize(Integer.parseInt(record1.get(6)));
-            q.setGeneration(q.getLength());
+
             if (rules1.contains(q)) {
                 System.err.println("[DUP] Duplicate rule in file:");
                 System.err.println(q.getRuleString());

--- a/rules/src/main/java/amie/rules/AMIEParser.java
+++ b/rules/src/main/java/amie/rules/AMIEParser.java
@@ -15,71 +15,71 @@ import it.unimi.dsi.fastutil.ints.IntList;
 import javatools.datatypes.Pair;
 import javatools.filehandlers.FileLines;
 
-/** 
+/**
  * Parses a file of AMIE rules
- * 
- * @author Fabian
  *
+ * @author Fabian
  */
 public class AMIEParser {
-	
-	/**
-	 * Parsers an AMIE rule from a string.
-	 * @param s
-	 * @return
-	 */
-	public static Rule rule(String s) {	
-		Pair<List<int[]>, int[]> rulePair = KB.rule(s);
-		if(rulePair == null) return null;
-		Rule resultRule = new Rule(rulePair.second, rulePair.first, 0);
-		return resultRule;
-	}	
-  
-	public static void normalizeRule(Rule q){
-		char c = 'a';
-		Int2ObjectMap<Character> charmap = new Int2ObjectOpenHashMap<Character>();
-		for(int[] triple: q.getTriples()){
-			for(int i = 0;  i < triple.length; ++i){
-				if(KB.isVariable(triple[i])){
-					Character replace = charmap.get(triple[i]);
-					if(replace == null){
-						replace = new Character(c);
-						charmap.put(triple[i], replace);
-						c = (char) (c + 1);
-					}
-					triple[i] = KB.map("?" + replace);				
-				}
-			}
-		}
-	}	
 
-	public static List<Rule> rules(File f) throws IOException {
-	    List<Rule> result=new ArrayList<>();
-	    for(String line : new FileLines(f)) {
-	    	ArrayList<int[]> triples=KB.triples(line);
-	    	if(triples==null || triples.size()<2) continue;      
-	    	int[] last=triples.get(triples.size()-1);
-	    	triples.remove(triples.size()-1);
-	    	triples.add(0, last);
-	    	Rule query=new Rule();
-	 
-	    	IntList variables = new IntArrayList();
-	    	for(int[] triple: triples){
-	    		if(!variables.contains(triple[0]))
-	    			variables.add(triple[0]);
-	    		if(!variables.contains(triple[2]))
-	    			variables.add(triple[2]);
-	    	}
-	      
-	    	query.setSupport(0);
-	    	query.setTriples(triples);
-	    	query.setFunctionalVariablePosition(0);
-	    	result.add(query);
-	    }
-	    return(result);
-	}
-	  
-	public static void main(String[] args) throws Exception {
-	    System.out.println(AMIEParser.rule("=> ?a <hasChild> ?b"));
-	}
+    /**
+     * Parsers an AMIE rule from a string.
+     *
+     * @param s
+     * @return
+     */
+    public static Rule rule(String s) {
+        Pair<List<int[]>, int[]> rulePair = KB.rule(s);
+        if (rulePair == null) return null;
+        Rule resultRule = new Rule(rulePair.second, rulePair.first, 0);
+        return resultRule;
+    }
+
+    public static void normalizeRule(Rule q) {
+        char c = 'a';
+        Int2ObjectMap<Character> charmap = new Int2ObjectOpenHashMap<Character>();
+        for (int[] triple : q.getTriples()) {
+            for (int i = 0; i < triple.length; ++i) {
+                if (KB.isVariable(triple[i])) {
+                    Character replace = charmap.get(triple[i]);
+                    if (replace == null) {
+                        replace = new Character(c);
+                        charmap.put(triple[i], replace);
+                        c = (char) (c + 1);
+                    }
+                    triple[i] = KB.map("?" + replace);
+                }
+            }
+        }
+    }
+
+    public static List<Rule> rules(File f) throws IOException {
+        List<Rule> result = new ArrayList<>();
+        for (String line : new FileLines(f)) {
+            ArrayList<int[]> triples = KB.triples(line);
+            if (triples == null || triples.size() < 2) continue;
+            int[] last = triples.get(triples.size() - 1);
+            triples.remove(triples.size() - 1);
+            triples.add(0, last);
+            Rule query = new Rule();
+
+            IntList variables = new IntArrayList();
+            for (int[] triple : triples) {
+                if (!variables.contains(triple[0]))
+                    variables.add(triple[0]);
+                if (!variables.contains(triple[2]))
+                    variables.add(triple[2]);
+            }
+
+            query.setSupport(0);
+            query.setTriples(triples);
+            query.setFunctionalVariablePosition(0);
+            result.add(query);
+        }
+        return (result);
+    }
+
+    public static void main(String[] args) throws Exception {
+        System.out.println(AMIEParser.rule("=> ?a <hasChild> ?b"));
+    }
 }

--- a/rules/src/main/java/amie/rules/eval/TSVRuleDiff.java
+++ b/rules/src/main/java/amie/rules/eval/TSVRuleDiff.java
@@ -55,7 +55,7 @@ public class TSVRuleDiff {
 
         //Preprocess one of the files
         for (List<String> record1 : tsv1) {
-            Rule q = AMIEParser.rule(record1.get(0).trim());
+            Rule q = AMIEParser.rule(record1);
             if (q == null) continue;
             if (rules1.containsKey(q)) {
                 System.err.println("[DUP] in first file:");
@@ -67,7 +67,7 @@ public class TSVRuleDiff {
         }
 
         for (List<String> record2 : tsv2) {
-            Rule q = AMIEParser.rule(record2.get(0).trim());
+            Rule q = AMIEParser.rule(record2);
             if (q == null) continue;
             if (rules2.containsKey(q)) {
                 System.err.println("[DUP] in second file:");


### PR DESCRIPTION
This PR changes `AMIEParser` in two ways:
- `AMIEParser.rules` now consumes the file as a `TSVFile`. Therefore, it can be used both with a file containing only the rule in each line, or a file containing a rule and other `\t`-separeted data.
- If other `\t`-separeted data is available, `AMIEParser.rules` will try to load it as the rule's associated data.

This **might break things**, since it assumes that the extra data follows at least the sequence of: **"Head Coverage"**, "Std Confidence", "PCA Confidence", **"Positive Examples"**, **"Body size"**, **"PCA Body size"**, **"Functional variable"** (all highlighted fields are loaded).

Commit 92543f1 just reformats the code, and a7ebf20 implements the modifications.

