### PR TITLE
Tsv parser

### DIFF
--- a/rules/src/main/java/amie/rules/AMIEParser.java
+++ b/rules/src/main/java/amie/rules/AMIEParser.java
@@ -14,6 +14,7 @@ import it.unimi.dsi.fastutil.ints.IntList;
 
 import javatools.datatypes.Pair;
 import javatools.filehandlers.FileLines;
+import javatools.filehandlers.TSVFile;
 
 /**
  * Parses a file of AMIE rules
@@ -55,28 +56,13 @@ public class AMIEParser {
 
     public static List<Rule> rules(File f) throws IOException {
         List<Rule> result = new ArrayList<>();
-        for (String line : new FileLines(f)) {
-            ArrayList<int[]> triples = KB.triples(line);
-            if (triples == null || triples.size() < 2) continue;
-            int[] last = triples.get(triples.size() - 1);
-            triples.remove(triples.size() - 1);
-            triples.add(0, last);
-            Rule query = new Rule();
+        for (List<String> record : new TSVFile(f)) {
+            Rule query = rule(record.get(0));
 
-            IntList variables = new IntArrayList();
-            for (int[] triple : triples) {
-                if (!variables.contains(triple[0]))
-                    variables.add(triple[0]);
-                if (!variables.contains(triple[2]))
-                    variables.add(triple[2]);
-            }
-
-            query.setSupport(0);
-            query.setTriples(triples);
-            query.setFunctionalVariablePosition(0);
-            result.add(query);
+            if (query != null)
+                result.add(query);
         }
-        return (result);
+        return result;
     }
 
     public static void main(String[] args) throws Exception {

--- a/rules/src/main/java/amie/rules/AMIEParser.java
+++ b/rules/src/main/java/amie/rules/AMIEParser.java
@@ -15,71 +15,71 @@ import it.unimi.dsi.fastutil.ints.IntList;
 import javatools.datatypes.Pair;
 import javatools.filehandlers.FileLines;
 
-/** 
+/**
  * Parses a file of AMIE rules
- * 
- * @author Fabian
  *
+ * @author Fabian
  */
 public class AMIEParser {
-	
-	/**
-	 * Parsers an AMIE rule from a string.
-	 * @param s
-	 * @return
-	 */
-	public static Rule rule(String s) {	
-		Pair<List<int[]>, int[]> rulePair = KB.rule(s);
-		if(rulePair == null) return null;
-		Rule resultRule = new Rule(rulePair.second, rulePair.first, 0);
-		return resultRule;
-	}	
-  
-	public static void normalizeRule(Rule q){
-		char c = 'a';
-		Int2ObjectMap<Character> charmap = new Int2ObjectOpenHashMap<Character>();
-		for(int[] triple: q.getTriples()){
-			for(int i = 0;  i < triple.length; ++i){
-				if(KB.isVariable(triple[i])){
-					Character replace = charmap.get(triple[i]);
-					if(replace == null){
-						replace = new Character(c);
-						charmap.put(triple[i], replace);
-						c = (char) (c + 1);
-					}
-					triple[i] = KB.map("?" + replace);				
-				}
-			}
-		}
-	}	
 
-	public static List<Rule> rules(File f) throws IOException {
-	    List<Rule> result=new ArrayList<>();
-	    for(String line : new FileLines(f)) {
-	    	ArrayList<int[]> triples=KB.triples(line);
-	    	if(triples==null || triples.size()<2) continue;      
-	    	int[] last=triples.get(triples.size()-1);
-	    	triples.remove(triples.size()-1);
-	    	triples.add(0, last);
-	    	Rule query=new Rule();
-	 
-	    	IntList variables = new IntArrayList();
-	    	for(int[] triple: triples){
-	    		if(!variables.contains(triple[0]))
-	    			variables.add(triple[0]);
-	    		if(!variables.contains(triple[2]))
-	    			variables.add(triple[2]);
-	    	}
-	      
-	    	query.setSupport(0);
-	    	query.setTriples(triples);
-	    	query.setFunctionalVariablePosition(0);
-	    	result.add(query);
-	    }
-	    return(result);
-	}
-	  
-	public static void main(String[] args) throws Exception {
-	    System.out.println(AMIEParser.rule("=> ?a <hasChild> ?b"));
-	}
+    /**
+     * Parsers an AMIE rule from a string.
+     *
+     * @param s
+     * @return
+     */
+    public static Rule rule(String s) {
+        Pair<List<int[]>, int[]> rulePair = KB.rule(s);
+        if (rulePair == null) return null;
+        Rule resultRule = new Rule(rulePair.second, rulePair.first, 0);
+        return resultRule;
+    }
+
+    public static void normalizeRule(Rule q) {
+        char c = 'a';
+        Int2ObjectMap<Character> charmap = new Int2ObjectOpenHashMap<Character>();
+        for (int[] triple : q.getTriples()) {
+            for (int i = 0; i < triple.length; ++i) {
+                if (KB.isVariable(triple[i])) {
+                    Character replace = charmap.get(triple[i]);
+                    if (replace == null) {
+                        replace = new Character(c);
+                        charmap.put(triple[i], replace);
+                        c = (char) (c + 1);
+                    }
+                    triple[i] = KB.map("?" + replace);
+                }
+            }
+        }
+    }
+
+    public static List<Rule> rules(File f) throws IOException {
+        List<Rule> result = new ArrayList<>();
+        for (String line : new FileLines(f)) {
+            ArrayList<int[]> triples = KB.triples(line);
+            if (triples == null || triples.size() < 2) continue;
+            int[] last = triples.get(triples.size() - 1);
+            triples.remove(triples.size() - 1);
+            triples.add(0, last);
+            Rule query = new Rule();
+
+            IntList variables = new IntArrayList();
+            for (int[] triple : triples) {
+                if (!variables.contains(triple[0]))
+                    variables.add(triple[0]);
+                if (!variables.contains(triple[2]))
+                    variables.add(triple[2]);
+            }
+
+            query.setSupport(0);
+            query.setTriples(triples);
+            query.setFunctionalVariablePosition(0);
+            result.add(query);
+        }
+        return (result);
+    }
+
+    public static void main(String[] args) throws Exception {
+        System.out.println(AMIEParser.rule("=> ?a <hasChild> ?b"));
+    }
 }


### PR DESCRIPTION
This PR changes `AMIEParser` in two ways:
- `AMIEParser.rules` now consumes the file as a `TSVFile`. Therefore, it can be used both with a file containing only the rule in each line, or a file containing a rule and other `\t`-separeted data.
- The parsing is now done through `KB.rule`, instead of `KB.triples`.

Commit 92543f141b27916c8696ef2245511c9488cb2d7a just reformats the code, and b9085ab5a15dbb3314c82a7349c6b8e4d8f4e06c implements the modifications.