### PR TITLE
[Operators] Fix #43 - Improved exploit max length for dangling operator

### DIFF
--- a/mining/src/main/java/amie/mining/AMIE.java
+++ b/mining/src/main/java/amie/mining/AMIE.java
@@ -416,35 +416,11 @@ public class AMIE {
                         double threshold = getCountThreshold(currentRule);
 
                         // Application of the mining operators
-                        Map<String, Collection<Rule>> temporalOutputMap = null;
                         try {
-                            temporalOutputMap = assistant.applyMiningOperators(currentRule, threshold);
-                        } catch (IllegalAccessException e) {
-                            // TODO Auto-generated catch block
+                            Map<String, Collection<Rule>> temporalOutputMap = assistant.applyMiningOperators(currentRule, threshold);
+                            temporalOutputMap.values().forEach(queryPool::queueAll);
+                        } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
                             e.printStackTrace();
-                        } catch (IllegalArgumentException e) {
-                            // TODO Auto-generated catch block
-                            e.printStackTrace();
-                        } catch (InvocationTargetException e) {
-                            // TODO Auto-generated catch block
-                            e.printStackTrace();
-                        }
-
-                        for (Map.Entry<String, Collection<Rule>> entry : temporalOutputMap.entrySet()) {
-                            String operator = entry.getKey();
-                            Collection<Rule> items = entry.getValue();
-                            if (!operator.equals("dangling")) {
-                                queryPool.queueAll(items);
-                            }
-                        }
-
-                        // Addition of the specializations to the queue
-                        //queryPool.queueAll(temporalOutput);
-                        if (currentRule.getRealLength()
-                                < assistant.getMaxDepth() - 1) {
-                            if (temporalOutputMap.containsKey("dangling")) {
-                                queryPool.queueAll(temporalOutputMap.get("dangling"));
-                            }
                         }
                     }
 

--- a/mining/src/main/java/amie/mining/assistant/DefaultMiningAssistant.java
+++ b/mining/src/main/java/amie/mining/assistant/DefaultMiningAssistant.java
@@ -248,9 +248,12 @@ public class DefaultMiningAssistant extends MiningAssistant{
 		// Pruning by maximum length for the \mathcal{O}_D operator.
 		if(query.getRealLength() == this.maxDepth - 1) {
 			if (this.exploitMaxLengthOption) {
-				if(!query.getOpenVariables().isEmpty() 
-						&& !this.allowConstants 
-						&& !this.enforceConstants) {
+				if (query.getOpenVariables().size() > 1) {
+					return;
+				}
+
+				if (query.getOpenVariables().size() == 1
+						&& !canAddInstantiatedAtoms()) {
 					return;
 				}
 			}

--- a/mining/src/main/java/amie/mining/assistant/DefaultMiningAssistant.java
+++ b/mining/src/main/java/amie/mining/assistant/DefaultMiningAssistant.java
@@ -249,11 +249,12 @@ public class DefaultMiningAssistant extends MiningAssistant{
 		if(query.getRealLength() == this.maxDepth - 1) {
 			if (this.exploitMaxLengthOption) {
 				if (query.getOpenVariables().size() > 1) {
+					// There will be more than 2 open variables and we will not be able to close all of them.
 					return;
 				}
 
-				if (query.getOpenVariables().size() == 1
-						&& !canAddInstantiatedAtoms()) {
+				if (!canAddInstantiatedAtoms()) {
+					// We can't count on instantiation operator to close the new dangling variable.
 					return;
 				}
 			}

--- a/mining/src/main/java/amie/mining/assistant/MiningAssistant.java
+++ b/mining/src/main/java/amie/mining/assistant/MiningAssistant.java
@@ -599,7 +599,11 @@ public class MiningAssistant {
 
 		if (exploitMaxLengthOption) {
 			if(rule.getRealLength() == maxDepth - 1){
-				if(!rule.getOpenVariables().isEmpty() && !allowConstants){
+				if (rule.getOpenVariables().size() > 1) {
+					return;
+				}
+
+				if (rule.getOpenVariables().size() == 1 && !allowConstants) {
 					return;
 				}
 			}

--- a/mining/src/main/java/amie/mining/assistant/MiningAssistant.java
+++ b/mining/src/main/java/amie/mining/assistant/MiningAssistant.java
@@ -600,10 +600,12 @@ public class MiningAssistant {
 		if (exploitMaxLengthOption) {
 			if(rule.getRealLength() == maxDepth - 1){
 				if (rule.getOpenVariables().size() > 1) {
+					// There will be more than 2 open variables and we will not be able to close all of them.
 					return;
 				}
 
-				if (rule.getOpenVariables().size() == 1 && !allowConstants) {
+				if (!canAddInstantiatedAtoms()) {
+					// We can't count on instantiation operator to close the new dangling variable.
 					return;
 				}
 			}

--- a/mining/src/main/java/amie/mining/assistant/experimental/SeedsCountMiningAssistant.java
+++ b/mining/src/main/java/amie/mining/assistant/experimental/SeedsCountMiningAssistant.java
@@ -206,12 +206,13 @@ public class SeedsCountMiningAssistant extends MiningAssistant {
 		//General case
 		if(query.getLength() == maxDepth - 1) {
 			if (this.exploitMaxLengthOption) {
-				if (openVariables.size() > 1) {
+				if (query.getOpenVariables().size() > 1) {
+					// There will be more than 2 open variables and we will not be able to close all of them.
 					return;
 				}
 
-				if (openVariables.size() == 1
-						&& !canAddInstantiatedAtoms()) {
+				if (!canAddInstantiatedAtoms()) {
+					// We can't count on instantiation operator to close the new dangling variable.
 					return;
 				}
 			}

--- a/mining/src/main/java/amie/mining/assistant/experimental/SeedsCountMiningAssistant.java
+++ b/mining/src/main/java/amie/mining/assistant/experimental/SeedsCountMiningAssistant.java
@@ -206,9 +206,12 @@ public class SeedsCountMiningAssistant extends MiningAssistant {
 		//General case
 		if(query.getLength() == maxDepth - 1) {
 			if (this.exploitMaxLengthOption) {
-				if(!openVariables.isEmpty() 
-						&& !this.allowConstants 
-						&& !this.enforceConstants) {
+				if (openVariables.size() > 1) {
+					return;
+				}
+
+				if (openVariables.size() == 1
+						&& !canAddInstantiatedAtoms()) {
 					return;
 				}
 			}


### PR DESCRIPTION
This PR implements the modification proposed in #43. I've updated all mining assistants that I could find in `master`. 

This PR would also benefit assistants on other branches (such as the Injective assistant).

I've run some basic tests with `-maxad 3` and `-maxad 4`, comparing mined rules before and after this patch. `TSVRuleDiff` reports no difference between mined rules. 

I can see a performance improvement (though I did not benchmark it).
AMIE queue calls to the last generation drops by about half.