### PR TITLE
[AMIEQueue] Add progress bar for each generation

### DIFF
--- a/mining/pom.xml
+++ b/mining/pom.xml
@@ -16,12 +16,6 @@
   </properties>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>3.8.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
       <version>1.3.1</version>
@@ -30,6 +24,11 @@
     	<groupId>fr.enst.dbweb</groupId>
     	<artifactId>rules</artifactId>
     	<version>1.0</version>
+    </dependency>
+    <dependency>
+    	<groupId>me.tongfei</groupId>
+    	<artifactId>progressbar</artifactId>
+    	<version>0.8.1</version>
     </dependency>
   </dependencies>
 

--- a/mining/src/main/java/amie/mining/AMIE.java
+++ b/mining/src/main/java/amie/mining/AMIE.java
@@ -230,7 +230,7 @@ public class AMIE {
             seedRules = assistant.getInitialAtomsFromSeeds(seeds, minInitialSupport);
         }
 
-        AMIEQueue queue = new AMIEQueue(seedRules, nThreads);
+        AMIEQueue queue = new AMIEQueue(seedRules, nThreads, isVerbose());
 
         if (realTime) {
             consumerObj = new RuleConsumer(result, resultsLock, resultsCondVar);

--- a/mining/src/main/java/amie/mining/AMIEQueue.java
+++ b/mining/src/main/java/amie/mining/AMIEQueue.java
@@ -11,6 +11,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import amie.rules.Rule;
 import it.unimi.dsi.fastutil.ints.Int2IntMap;
 import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
+import me.tongfei.progressbar.ProgressBar;
 
 /**
  * A queue implementation with barriers tailored for the AMIE mining system.
@@ -31,6 +32,10 @@ public final class AMIEQueue {
 
 	private LinkedHashSet<Rule> next;
 
+	private ProgressBar progressBar;
+
+	private boolean verbose;
+
 	private int generation;
 
 	private int maxThreads;
@@ -49,13 +54,15 @@ public final class AMIEQueue {
             }
         }
 
-	public AMIEQueue(Collection<Rule> seeds, int maxThreads) {
+	public AMIEQueue(Collection<Rule> seeds, int maxThreads, boolean verbose) {
 		this.generation = 1;
                 this.queueCalls.put(this.generation, 0);
                 this.queueAdded.put(this.generation, 0);
 		this.maxThreads = maxThreads;
 		this.waitingThreads = 0;
 		this.next = new LinkedHashSet<>();
+		this.progressBar = null;
+		this.verbose = verbose;
 		this.queueAll(seeds);
 		this.nextGeneration();
                 this.done = false;
@@ -139,6 +146,9 @@ public final class AMIEQueue {
                     --waitingThreads;
                 } else {
                     if (next.isEmpty()) {
+                        if (this.verbose) {
+                            this.progressBar.close();
+                        }
                         done = true;
                     } else {
                         nextGeneration();
@@ -160,7 +170,10 @@ public final class AMIEQueue {
 	 * @return
 	 */
 	private Rule poll() {
-            return current.next();
+		if (this.verbose) {
+			this.progressBar.step();
+		}
+		return current.next();
 	}
 
 
@@ -168,6 +181,16 @@ public final class AMIEQueue {
 		generation++;
                 this.queueCalls.put(this.generation, 0);
                 this.queueAdded.put(this.generation, 0);
+
+		if (this.progressBar != null) {
+			this.progressBar.close();
+		}
+
+		if (this.verbose) {
+			// Heuristic for calculating updateIntervalMillis considering the queue's size and the number of consumers.
+			this.progressBar = new ProgressBar("Generation " + generation + ":", next.size(), Math.min(1000, next.size() * 1000 / 1000 / maxThreads));
+		}
+
 		current = next.iterator();
 		next = new LinkedHashSet<>();
 	}


### PR DESCRIPTION
This PR modifies the `AMIEQueue` such that it reports the mining progress using a progress bar (if `-verbose`). 
I've used the most active Java CLI progress bar I cound find (https://github.com/ctongfei/progressbar).

One (minor?) issue is that AMIE's logging conflicts with the line breaks, yielding some lines with both progressbar and AMIE logging. I think the only solution would be to use some logging module and redirect the different output types to different files.

I've also used a heuristic to set how often the progress bar should be updated. It seems to work on my small experiments, but I will still test it with bigger datasets.

I'm not sure yet about the overhead added by this (i) if verbose is not set, (ii) if verbose is set.

![AMIEQueue with ProgressBar](https://user-images.githubusercontent.com/8387736/93017550-083cdb80-f5a0-11ea-80c3-cb9ae9e84a81.png)
