### PR TITLE
[Operators] Fix #43 - Improved exploit max length for dangling operator

### DIFF
--- a/mining/src/main/java/amie/mining/assistant/DefaultMiningAssistant.java
+++ b/mining/src/main/java/amie/mining/assistant/DefaultMiningAssistant.java
@@ -248,9 +248,13 @@ public class DefaultMiningAssistant extends MiningAssistant{
 		// Pruning by maximum length for the \mathcal{O}_D operator.
 		if(query.getRealLength() == this.maxDepth - 1) {
 			if (this.exploitMaxLengthOption) {
-				if(!query.getOpenVariables().isEmpty() 
-						&& !this.allowConstants 
-						&& !this.enforceConstants) {
+				if (query.getOpenVariables().size() > 1) {
+					// There will be more than 2 open variables and we will not be able to close all of them.
+					return;
+				}
+
+				if (!canAddInstantiatedAtoms()) {
+					// We can't count on instantiation operator to close the new dangling variable.
 					return;
 				}
 			}

--- a/mining/src/main/java/amie/mining/assistant/MiningAssistant.java
+++ b/mining/src/main/java/amie/mining/assistant/MiningAssistant.java
@@ -600,7 +600,13 @@ public class MiningAssistant {
 
 		if (exploitMaxLengthOption) {
 			if(rule.getRealLength() == maxDepth - 1){
-				if(!rule.getOpenVariables().isEmpty() && !allowConstants){
+				if (rule.getOpenVariables().size() > 1) {
+					// There will be more than 2 open variables and we will not be able to close all of them.
+					return;
+				}
+
+				if (!canAddInstantiatedAtoms()) {
+					// We can't count on instantiation operator to close the new dangling variable.
 					return;
 				}
 			}

--- a/mining/src/main/java/amie/mining/assistant/experimental/SeedsCountMiningAssistant.java
+++ b/mining/src/main/java/amie/mining/assistant/experimental/SeedsCountMiningAssistant.java
@@ -206,9 +206,13 @@ public class SeedsCountMiningAssistant extends MiningAssistant {
 		//General case
 		if(query.getLength() == maxDepth - 1) {
 			if (this.exploitMaxLengthOption) {
-				if(!openVariables.isEmpty() 
-						&& !this.allowConstants 
-						&& !this.enforceConstants) {
+				if (query.getOpenVariables().size() > 1) {
+					// There will be more than 2 open variables and we will not be able to close all of them.
+					return;
+				}
+
+				if (!canAddInstantiatedAtoms()) {
+					// We can't count on instantiation operator to close the new dangling variable.
 					return;
 				}
 			}


### PR DESCRIPTION
This PR implements the modification proposed in #43. I've updated all mining assistants that I could find in `master`. 

This PR would also benefit assistants on other branches (such as the Injective assistant).

I've run some basic tests with `-maxad 3` and `-maxad 4`, comparing mined rules before and after this patch. `TSVRuleDiff` reports no difference between mined rules. 

This PR is slightly faster than master, and there is a huge performance improvement when mining constants. Also, AMIE queue calls to the last generation drops by about half.

## Basic benchmark:

Mean of 5 runs in a 500k triples KB.

Without constants:
```bash
Summary
  'java -jar dangling_amie3.jar -bias lazy -oute -full -minhc .1 -maxad 3 kb.nt' ran
    1.02 ± 0.05 times faster than 'java -jar amie3.jar -bias lazy -oute -full -minhc .1 -maxad 3 kb.nt'
```

With constants:
```bash

Summary
  'java -jar dangling_amie3.jar -bias lazy -const -oute -full -minhc .1 -maxad 3 kb.nt' ran
    6.08 ± 0.21 times faster than 'java -jar amie3.jar -bias lazy -const -oute -full -minhc .1 -maxad 3 kb.nt'
```