### PR TITLE
Configure abstruse ci 

### DIFF
--- a/.abstruse.yml
+++ b/.abstruse.yml
@@ -1,0 +1,16 @@
+image: openjdk:8
+
+before_install:
+  - apt-get update
+  - apt-get install -y git
+  - apt-get install -y software-properties-common
+  - apt-get update
+  - apt-get install -y  maven
+  - git clone https://github.com/lajus/amie-utils
+  - cd amie-utils/javatools/ && mvn install
+
+install:
+  - mvn clean install
+
+script:
+  - mvn test


### PR DESCRIPTION
Hello, I have created a .abstruse.yml to run tests (https://abstruse.bleenco.io/~)
However, the owner of the repository need to:

- [ ] Configure github webhooks (https://github.com/bleenco/abstruse/blob/master/docs/INTEGRATING_GIT_PROVIDERS.md) 

- [ ] Configure a local server that runs abstruse ( launch demo server locally with docker https://github.com/bleenco/abstruse) 

You can see how the ci perform here : https://github.com/Fran-cois/amie (in readme ==> Build status